### PR TITLE
Add cyrillic class to body when mn lang active

### DIFF
--- a/src/app/i18n/language-switcher/switcher.js
+++ b/src/app/i18n/language-switcher/switcher.js
@@ -1,13 +1,19 @@
 
 class LanguageSwitcherController {
   /** @ngInject */
-  constructor($translate) {
+  constructor($document, $translate) {
     this.$translate = $translate;
+    this.$document = $document;
   }
 
   onSwitcherClicked() {
     const currentLang = this.$translate.use();
     const newLang = currentLang === 'en' ? 'mn' : 'en';
+    if (newLang === 'mn') {
+      this.$document.find('html').addClass('cyrillic');
+    } else {
+      this.$document.find('html').removeClass('cyrillic');
+    }
     this.$translate.use(newLang);
   }
 }


### PR DESCRIPTION
Thanks to @designmatty for pointing this out, missed this in the prototype.

Switching the class updates the font-family to one that is known to support all of the cyrillic characters.
