### PR TITLE
Toggleable overlays and changeable basemaps

### DIFF
--- a/src/app/adb-map.controller.js
+++ b/src/app/adb-map.controller.js
@@ -14,7 +14,7 @@ export class ADBMapController {
 
   _setupMap(options) {
     const view = options.view;
-    const basemap = options.basemap;
+    const basemap = options.basemaps.default;
     // Make a copy of the Config so we don't actually change it
     const mapOptions = Object.create(basemap.options);
     // Translate the attributions message

--- a/src/app/views/infoblock/infoblock.html
+++ b/src/app/views/infoblock/infoblock.html
@@ -1,4 +1,4 @@
 <div class="panel-content text-center">
-  <h2 ng-class="$ctrl.colorClass">{{ ::$ctrl.value | comparatize:$ctrl.isComparison:$ctrl.isPercent }}</h2>
+  <h2 ng-class="$ctrl.colorClass">{{ ::$ctrl.value | comparatize:$ctrl.isChange:$ctrl.isPercent }}</h2>
   <p class="font-alt color-light text-uppercase" translate="{{ ::$ctrl.title }}"></p>
 </div>

--- a/src/config.js
+++ b/src/config.js
@@ -5,13 +5,44 @@ const config = {
     accountName: 'adbmongolia'
   },
   map: {
-    basemap: {
-      url: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-      options: {
-        attribution: 'MAP_OSM_ATTRIBUTION',
-        maxZoom: 19
-      }
+    basemaps: {
+      default: {
+        url: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+        title: 'MAP_DEFAULT_TITLE',
+        options: {
+          attribution: 'MAP_OSM_ATTRIBUTION',
+          maxZoom: 19
+        }
+      },
+      alternative: [{
+        url: 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
+        title: 'MAP_ARCGIS_WORLD_TOPO_MAP_TITLE',
+        options: {
+          attribution: 'MAP_ARCGIS_WORLD_TOPO_MAP_ATTRIBUTION',
+          maxZoom: 19
+        }
+      }, {
+        url: 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+        title: 'MAP_ARCGIS_WORLD_IMAGERY_TITLE',
+        options: {
+          attribution: 'MAP_ARCGIS_WORLD_IMAGERY_ATTRIBUTION',
+          maxZoom: 19
+        }
+      }]
     },
+    overlays: [{
+      id: '6626851e-6f8c-11e6-a376-0ee66e2c9693',
+      title: 'MAP_CLUSTERS_TITLE',
+      zIndex: 102
+    }, {
+      id: '256705a8-6f8c-11e6-b205-0e233c30368f',
+      title: 'MAP_ROADWAYS_TITLE',
+      zIndex: 101
+    }, {
+      id: '834fd12c-6f8c-11e6-b15b-0ee66e2c9693',
+      title: 'MAP_SETTLEMENTS_TITLE',
+      zIndex: 103
+    }],
     options: {
       zoomControl: false
     },

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -39,6 +39,8 @@ export const en = {
   DATA_BACK_TO_MAP: 'Back to Map',
 
   MAP_OSM_ATTRIBUTION: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+  MAP_ARCGIS_WORLD_IMAGERY_ATTRIBUTION: 'Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community',
+  MAP_ARCGIS_WORLD_TOPO_MAP_ATTRIBUTION: 'Sources: Esri, HERE, DeLorme, Intermap, increment P Corp., GEBCO, USGS, FAO, NPS, NRCAN, GeoBase, IGN, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), swisstopo, MapmyIndia, Â© OpenStreetMap contributors, and the GIS User Community',
   MAP_VIZ_POP: 'Population 2014',
   MAP_VIZ_POP_CHANGE: 'Population Change 1995-2014',
   MAP_VIZ_POP_SHARE: '% of Mongolia\'s Pop 2014',
@@ -60,6 +62,11 @@ export const en = {
   MAP_VIZ_INFR_INDOOR_SANITATION_PCT: '% of Population with Indoor Sanitation 2010',
   MAP_VIZ_INFR_PIPED_WATER_PCT: '% of Population with Access to Piped Water 2010',
   MAP_VIZ_INFR_SOLID_WASTE_DISPOSAL_PCT: '% of Population with Organized Solid Waste Disposal 2010',
-  MAP_VIZ_INFR_INTERNET_ACCESS_PCT: '% of Population with Access to Internet 2010'
-
+  MAP_VIZ_INFR_INTERNET_ACCESS_PCT: '% of Population with Access to Internet 2010',
+  MAP_DEFAULT_TITLE: 'Default',
+  MAP_ARCGIS_WORLD_TOPO_MAP_TITLE: 'Topographical',
+  MAP_ARCGIS_WORLD_IMAGERY_TITLE: 'Satelite',
+  MAP_ROADWAYS_TITLE: 'Show roadways',
+  MAP_CLUSTERS_TITLE: 'Show regional clusters',
+  MAP_SETTLEMENTS_TITLE: 'Show major settelemnts'
 };

--- a/src/i18n/mn.js
+++ b/src/i18n/mn.js
@@ -60,6 +60,10 @@ export const mn = {
   MAP_VIZ_INFR_INDOOR_SANITATION_PCT: '!% of Population with Indoor Sanitation 2010',
   MAP_VIZ_INFR_PIPED_WATER_PCT: '!% of Population with Access to Piped Water 2010',
   MAP_VIZ_INFR_SOLID_WASTE_DISPOSAL_PCT: '!% of Population with Organized Solid Waste Disposal 2010',
-  MAP_VIZ_INFR_INTERNET_ACCESS_PCT: '!% of Population with Access to Internet 2010'
-
+  MAP_VIZ_INFR_INTERNET_ACCESS_PCT: '!% of Population with Access to Internet 2010',
+  MAP_POSITRON_TITLE: '!Default',
+  MAP_DARK_MATTER_TITLE: '!Dark Matter',
+  MAP_ROADWAYS_TITLE: '!Show roadways',
+  MAP_CLUSTERS_TITLE: '!Show regional clusters',
+  MAP_SETTLEMENTS_TITLE: '!Show major settelemnts'
 };

--- a/src/i18n/mn.js
+++ b/src/i18n/mn.js
@@ -39,6 +39,8 @@ export const mn = {
   DATA_BACK_TO_MAP: '!Back to Map',
 
   MAP_OSM_ATTRIBUTION: '!&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+  MAP_ARCGIS_WORLD_IMAGERY_ATTRIBUTION: '!Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community',
+  MAP_ARCGIS_WORLD_TOPO_MAP_ATTRIBUTION: '!Sources: Esri, HERE, DeLorme, Intermap, increment P Corp., GEBCO, USGS, FAO, NPS, NRCAN, GeoBase, IGN, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), swisstopo, MapmyIndia, Â© OpenStreetMap contributors, and the GIS User Community',
   MAP_VIZ_POP: '!Population 2014',
   MAP_VIZ_POP_CHANGE: '!Population Change 1995-2014',
   MAP_VIZ_POP_SHARE: '!% of Mongolia\'s Pop 2014',
@@ -61,8 +63,9 @@ export const mn = {
   MAP_VIZ_INFR_PIPED_WATER_PCT: '!% of Population with Access to Piped Water 2010',
   MAP_VIZ_INFR_SOLID_WASTE_DISPOSAL_PCT: '!% of Population with Organized Solid Waste Disposal 2010',
   MAP_VIZ_INFR_INTERNET_ACCESS_PCT: '!% of Population with Access to Internet 2010',
-  MAP_POSITRON_TITLE: '!Default',
-  MAP_DARK_MATTER_TITLE: '!Dark Matter',
+  MAP_DEFAULT_TITLE: '!Default',
+  MAP_ARCGIS_WORLD_TOPO_MAP_TITLE: '!Topographical',
+  MAP_ARCGIS_WORLD_IMAGERY_TITLE: '!Satelite',
   MAP_ROADWAYS_TITLE: '!Show roadways',
   MAP_CLUSTERS_TITLE: '!Show regional clusters',
   MAP_SETTLEMENTS_TITLE: '!Show major settelemnts'


### PR DESCRIPTION
## Overview

Adds a Leaflet layer control to the Map page to configure which basemap is used, as well as offers options for drawing the regions, major settlements and roadways. The Data page is unchanged and only uses the defaults (No overlays and the default basemap).
### Demo

<img width="858" alt="screen shot 2016-08-31 at 3 16 08 pm" src="https://cloud.githubusercontent.com/assets/1032849/18142971/f6b9d6b6-6f8d-11e6-98e0-c6e2b10e19f9.png">
<img width="859" alt="screen shot 2016-08-31 at 3 16 24 pm" src="https://cloud.githubusercontent.com/assets/1032849/18142974/f8cd3826-6f8d-11e6-8eb2-959adb8b1e66.png">
<img width="858" alt="screen shot 2016-08-31 at 3 16 36 pm" src="https://cloud.githubusercontent.com/assets/1032849/18142976/fb76620a-6f8d-11e6-8ebd-b31e543453af.png">
### Testing
- Navigate to Map page
- Changing the radio box should result in different basemaps being used under the map
- Toggling checkboxes should result in adding the corresponding information on top of the map
