### PR TITLE
Zoom to Aimag

### DIFF
--- a/src/app/factories/index.js
+++ b/src/app/factories/index.js
@@ -1,0 +1,10 @@
+
+import angular from 'angular';
+
+import {ZoomToDropdownFactory} from './zoomtodropdown.factory';
+
+export const adbFactoriesModule = 'adb.factories';
+
+angular
+  .module(adbFactoriesModule, [])
+  .factory('ZoomToDropdown', ZoomToDropdownFactory);

--- a/src/app/factories/zoomtodropdown.factory.js
+++ b/src/app/factories/zoomtodropdown.factory.js
@@ -1,0 +1,72 @@
+const L = require('leaflet');
+
+export function ZoomToDropdownFactory() {
+  return L.Control.extend({
+    options: {
+      label: 'Zoom to',
+      default: 'Zoom to...',
+      position: 'topright',
+      choices: []
+    },
+
+    // Using the arrow shorthand clobbers "this", so we need to use the old way
+    onAdd: function (map) {
+      this.map = map;
+
+      const container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
+      const label = L.DomUtil.create('label', '', container);
+      this.dropdown = L.DomUtil.create('select', '', container);
+
+      this._reflowChoices();
+
+      label.innerHTML = this.options.label;
+
+      return container;
+    },
+
+    setChoices: function (choices) {
+      this.options.choices = choices;
+      this._reflowChoices();
+    },
+
+    _reflowChoices: function () {
+      if (!this.dropdown) {
+        return;
+      }
+      this.dropdown.removeEventListener('change', this.onSelect);
+
+      // Remove all child elements
+      while (this.dropdown.firstChild) {
+        this.dropdown.removeChild(this.dropdown.firstChild);
+      }
+
+      // Add the default option
+      this._createOption(this.options.default, undefined);
+      this.dropdown.selectedIndex = 0;
+
+      // Add the choices as options id'd by the key
+      for (let i = 0; i < this.options.choices.length; i++) {
+        const choice = this.options.choices[i];
+        this._createOption(choice.label, i);
+      }
+
+      // Re-add event listener
+      this.dropdown.addEventListener('change', this.onSelect.bind(this));
+    },
+
+    _createOption: function (label, id) {
+      const option = L.DomUtil.create('option', '', this.dropdown);
+      option.innerHTML = label;
+      option.id = id;
+    },
+
+    onSelect: function () {
+      const key = this.dropdown.options[this.dropdown.selectedIndex].id;
+      const geojson = this.options.choices[key].the_geom;
+      if (geojson) {
+        const geometry = L.geoJson(JSON.parse(geojson));
+        this.map.fitBounds(geometry);
+      }
+    }
+  });
+}

--- a/src/app/services/aimag-data.service.js
+++ b/src/app/services/aimag-data.service.js
@@ -1,0 +1,17 @@
+const cartodb = require('cartodb');
+
+/** @ngInject */
+export function AimagData($log, $q, Config) {
+  return {
+    list
+  };
+
+  function list() {
+    // Returns a list of Aimags with name and the GeoJSON boundary for each
+    const dfd = $q.defer();
+    const sql = new cartodb.SQL({user: Config.carto.accountName});
+    sql.execute("SELECT aimag AS label, ST_AsGeoJSON(the_geom) AS the_geom FROM aimags")
+      .done(data => dfd.resolve(data)).error(error => dfd.reject(error));
+    return dfd.promise;
+  }
+}

--- a/src/app/services/aimag-data.service.js
+++ b/src/app/services/aimag-data.service.js
@@ -10,7 +10,7 @@ export function AimagData($log, $q, Config) {
     // Returns a list of Aimags with name and the GeoJSON boundary for each
     const dfd = $q.defer();
     const sql = new cartodb.SQL({user: Config.carto.accountName});
-    sql.execute("SELECT aimag AS label, ST_AsGeoJSON(the_geom) AS the_geom FROM aimags")
+    sql.execute("SELECT aimag AS label, ST_AsGeoJSON(the_geom) AS the_geom FROM aimags WHERE aimag IS NOT NULL")
       .done(data => dfd.resolve(data)).error(error => dfd.reject(error));
     return dfd.promise;
   }

--- a/src/app/services/aimag-data.service.js
+++ b/src/app/services/aimag-data.service.js
@@ -10,7 +10,7 @@ export function AimagData($log, $q, Config) {
     // Returns a list of Aimags with name and the GeoJSON boundary for each
     const dfd = $q.defer();
     const sql = new cartodb.SQL({user: Config.carto.accountName});
-    sql.execute("SELECT aimag AS label, ST_AsGeoJSON(the_geom) AS the_geom FROM aimags WHERE aimag IS NOT NULL")
+    sql.execute("SELECT aimag AS label, ST_AsGeoJSON(the_geom) AS the_geom FROM aimags WHERE aimag IS NOT NULL ORDER BY aimag")
       .done(data => dfd.resolve(data)).error(error => dfd.reject(error));
     return dfd.promise;
   }

--- a/src/app/services/index.js
+++ b/src/app/services/index.js
@@ -3,9 +3,11 @@ import angular from 'angular';
 
 import {appConfig} from '../../config';
 import {SoumData} from './soum-data.service';
+import {AimagData} from './aimag-data.service';
 
 export const adbServicesModule = 'adb.services';
 
 angular
   .module(adbServicesModule, [appConfig])
-  .service('SoumData', SoumData);
+  .service('SoumData', SoumData)
+  .service('AimagData', AimagData);

--- a/src/app/views/index.js
+++ b/src/app/views/index.js
@@ -9,12 +9,13 @@ import {adbInfoblockView} from './infoblock/infoblock';
 import {appConfig} from '../../config';
 import {adbLangModule} from '../i18n/index';
 import {adbServicesModule} from '../services/index';
+import {adbFactoriesModule} from '../factories/index';
 import {adbFiltersModule} from '../filters/index';
 
 export const adbViewModule = 'adb.views';
 
 angular
-  .module(adbViewModule, [appConfig, adbLangModule, adbServicesModule, adbFiltersModule])
+  .module(adbViewModule, [appConfig, adbLangModule, adbServicesModule, adbFiltersModule, adbFactoriesModule])
   .component('adbNavbarView', adbNavbarView)
   .component('adbHomeView', adbHomeView)
   .component('adbMapView', adbMapView)

--- a/src/app/views/map/map.js
+++ b/src/app/views/map/map.js
@@ -5,11 +5,10 @@ import {ADBMapController} from '../../adb-map.controller';
 
 L.Control.ZoomToDropdown = L.Control.extend({
   options: {
-    label: 'Select one',
+    label: 'Zoom to',
+    default: 'Zoom to...',
     position: 'topright',
-    choices: [{
-      label: 'Select...'
-    }]
+    choices: []
   },
 
   // Using the arrow shorthand clobbers "this", so we need to use the old way
@@ -36,30 +35,38 @@ L.Control.ZoomToDropdown = L.Control.extend({
     if (!this.dropdown) {
       return;
     }
-    this.dropdown.removeEventListener('change', this.onSelect)
+    this.dropdown.removeEventListener('change', this.onSelect);
 
     // Remove all child elements
     while (this.dropdown.firstChild) {
       this.dropdown.removeChild(this.dropdown.firstChild);
     }
 
+    // Add the default option
+    this._createOption(this.options.default, undefined);
+    this.dropdown.selectedIndex = 0;
+
     // Add the choices as options id'd by the key
     for (let i = 0; i < this.options.choices.length; i++) {
       const choice = this.options.choices[i];
-      const option = L.DomUtil.create('option', '', this.dropdown);
-      option.innerHTML = choice.label;
-      option.id = i;
+      this._createOption(choice.label, i);
     }
 
     // Re-add event listener
     this.dropdown.addEventListener('change', this.onSelect.bind(this));
   },
 
+  _createOption: function (label, id, selected) {
+    const option = L.DomUtil.create('option', '', this.dropdown);
+    option.innerHTML = label;
+    option.id = id;
+  },
+
   onSelect: function (event) {
     const key = this.dropdown.options[this.dropdown.selectedIndex].id;
-    if (this.options.choices[key].the_geom) {
-      const geojson = JSON.parse(this.options.choices[key].the_geom)
-      const geometry = L.geoJson(geojson);
+    const geojson = this.options.choices[key].the_geom;
+    if (geojson) {
+      const geometry = L.geoJson(JSON.parse(geojson));
       this.map.fitBounds(geometry);
     }
   }
@@ -154,7 +161,9 @@ class MapViewController extends ADBMapController {
   }
 
   _setupZoomDropdown() {
-    this.zoomControl = new L.Control.ZoomToDropdown();
+    this.zoomControl = new L.Control.ZoomToDropdown({
+      label: 'Zoom to Aimag'
+    });
 
     this.AimagData.list().then(data => {
       this.zoomControl.setChoices(data.rows);

--- a/src/app/views/map/map.js
+++ b/src/app/views/map/map.js
@@ -94,7 +94,8 @@ class MapViewController extends ADBMapController {
 
   _setupZoomDropdown() {
     this.zoomControl = new this.ZoomToDropdown({
-      label: 'Zoom to Aimag'
+      label: this.$filter('translate')('ZOOM_TO_AIMAG_PROMPT'),
+      default: this.$filter('translate')('ZOOM_TO_AIMAG_DEFAULT')
     });
 
     this.AimagData.list().then(data => {

--- a/src/app/views/map/map.js
+++ b/src/app/views/map/map.js
@@ -3,81 +3,13 @@ const L = require('leaflet');
 
 import {ADBMapController} from '../../adb-map.controller';
 
-L.Control.ZoomToDropdown = L.Control.extend({
-  options: {
-    label: 'Zoom to',
-    default: 'Zoom to...',
-    position: 'topright',
-    choices: []
-  },
-
-  // Using the arrow shorthand clobbers "this", so we need to use the old way
-  onAdd: function (map) {
-    this.map = map;
-
-    const container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
-    const label = L.DomUtil.create('label', '', container);
-    this.dropdown = L.DomUtil.create('select', '', container);
-
-    this._reflowChoices();
-
-    label.innerHTML = this.options.label;
-
-    return container;
-  },
-
-  setChoices: function (choices) {
-    this.options.choices = choices;
-    this._reflowChoices();
-  },
-
-  _reflowChoices: function () {
-    if (!this.dropdown) {
-      return;
-    }
-    this.dropdown.removeEventListener('change', this.onSelect);
-
-    // Remove all child elements
-    while (this.dropdown.firstChild) {
-      this.dropdown.removeChild(this.dropdown.firstChild);
-    }
-
-    // Add the default option
-    this._createOption(this.options.default, undefined);
-    this.dropdown.selectedIndex = 0;
-
-    // Add the choices as options id'd by the key
-    for (let i = 0; i < this.options.choices.length; i++) {
-      const choice = this.options.choices[i];
-      this._createOption(choice.label, i);
-    }
-
-    // Re-add event listener
-    this.dropdown.addEventListener('change', this.onSelect.bind(this));
-  },
-
-  _createOption: function (label, id, selected) {
-    const option = L.DomUtil.create('option', '', this.dropdown);
-    option.innerHTML = label;
-    option.id = id;
-  },
-
-  onSelect: function (event) {
-    const key = this.dropdown.options[this.dropdown.selectedIndex].id;
-    const geojson = this.options.choices[key].the_geom;
-    if (geojson) {
-      const geometry = L.geoJson(JSON.parse(geojson));
-      this.map.fitBounds(geometry);
-    }
-  }
-});
-
 class MapViewController extends ADBMapController {
   /** @ngInject */
-  constructor($filter, $log, AimagData, Config) {
+  constructor($filter, $log, AimagData, Config, ZoomToDropdown) {
     super($filter, Config, 'map');
     this.$log = $log;
     this.AimagData = AimagData;
+    this.ZoomToDropdown = ZoomToDropdown;
   }
 
   $onInit() {
@@ -161,7 +93,7 @@ class MapViewController extends ADBMapController {
   }
 
   _setupZoomDropdown() {
-    this.zoomControl = new L.Control.ZoomToDropdown({
+    this.zoomControl = new this.ZoomToDropdown({
       label: 'Zoom to Aimag'
     });
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -68,5 +68,7 @@ export const en = {
   MAP_ARCGIS_WORLD_IMAGERY_TITLE: 'Satelite',
   MAP_ROADWAYS_TITLE: 'Show roadways',
   MAP_CLUSTERS_TITLE: 'Show regional clusters',
-  MAP_SETTLEMENTS_TITLE: 'Show major settelemnts'
+  MAP_SETTLEMENTS_TITLE: 'Show major settelemnts',
+  ZOOM_TO_AIMAG_PROMPT: 'Zoom to Aimag',
+  ZOOM_TO_AIMAG_DEFAULT: 'Zoom to...'
 };

--- a/src/i18n/mn.js
+++ b/src/i18n/mn.js
@@ -68,5 +68,7 @@ export const mn = {
   MAP_ARCGIS_WORLD_IMAGERY_TITLE: '!Satelite',
   MAP_ROADWAYS_TITLE: '!Show roadways',
   MAP_CLUSTERS_TITLE: '!Show regional clusters',
-  MAP_SETTLEMENTS_TITLE: '!Show major settelemnts'
+  MAP_SETTLEMENTS_TITLE: '!Show major settelemnts',
+  ZOOM_TO_AIMAG_PROMPT: '!Zoom to Aimag',
+  ZOOM_TO_AIMAG_DEFAULT: '!Zoom to...'
 };


### PR DESCRIPTION
## Overview

Adds a dropdown to the map page that can be used to focus the view on a selected aimag via a factory that creates the ZoomToDropdown Leaflet control
### Demo

<img width="926" alt="screen shot 2016-09-16 at 4 44 47 pm" src="https://cloud.githubusercontent.com/assets/1032849/18600687/009a952a-7c2d-11e6-92af-6a566189a0a6.png">
<img width="929" alt="screen shot 2016-09-16 at 4 44 55 pm" src="https://cloud.githubusercontent.com/assets/1032849/18600689/036ad134-7c2d-11e6-8bb6-3a2899754e53.png">
<img width="930" alt="screen shot 2016-09-16 at 4 45 05 pm" src="https://cloud.githubusercontent.com/assets/1032849/18600691/06f4f15e-7c2d-11e6-85f1-be4d7d1d7c42.png">
## Testing
- Navigate to the Maps page
- The "Zoom to..." box should load and provide a list of available aimags
- Selecting an aimag should zoom the map to contain that aimag and its constituent soums.
