### PR TITLE
clean up the zoom controls on the map page

### DIFF
--- a/src/assets/sass/components/_map.scss
+++ b/src/assets/sass/components/_map.scss
@@ -101,6 +101,70 @@
   }
 }
 
+/* 
+ * Leaflet zoom controls for main map page
+ */
+#map .leaflet-top.leaflet-right {
+  padding: 10px;
+  background: white;
+  border: 1px solid #999;
+  border-radius: 4px;
+  box-shadow: rgba(0,0,0,.2) 0 0 4px 2px;
+  border-top: none;
+  border-right: none;
+  z-index: 99999;
+  top: 10px;
+  right: 20px;
+
+  .leaflet-control-zoom {
+    box-shadow: none;
+    border: 1px solid #ddd;
+    clear: none;
+    margin: 0;
+    margin-left: 10px;
+  }
+
+  .leaflet-control.leaflet-control-custom {
+    box-shadow: none;
+    float: right;
+    top: 0;
+    right: 0;
+    clear: none;
+    margin: 0;
+
+    label {
+      font-family: "lato";
+      font-weight: bold;
+      font-size: 13px;
+      text-transform: uppercase;
+      color: #666;
+      margin-bottom: 1px;
+      display: block;
+      padding-right: 10px;
+    }
+
+    select {
+      display: block;
+      width: 100%;
+      height: 34px;
+      padding: 6px 12px;
+      font-size: 14px;
+      line-height: 1.42857143;
+      color: #555;
+      background-color: #fff;
+      background-image: none;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+      -webkit-transition: border-color ease-in-out .15s,-webkit-box-shadow ease-in-out .15s;
+      -o-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+      transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+    }
+  }
+}
+
+
 @media (max-width: 728px) {
   #map {
     position: relative;


### PR DESCRIPTION
- Cleans up the zoom controls on the main map page
  - _Note: These changes do not apply to the data report map._
- Closes #31 

<img width="454" alt="screen shot 2016-09-20 at 1 31 32 pm" src="https://cloud.githubusercontent.com/assets/1928955/18681567/a717e568-7f36-11e6-86dc-2e6eb9196d9b.png">
