### PR TITLE
Comparative data

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "dependencies": {
     "angular": "1.5.8",
     "angular-translate": "2.11.1",
-    "angular-ui-router": "0.3.1"
+    "angular-ui-router": "0.3.1",
+    "d3": "3.5.5",
+    "lodash": "4.15.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.8",

--- a/src/app/controllers/charting.controller.js
+++ b/src/app/controllers/charting.controller.js
@@ -1,0 +1,64 @@
+/**
+ * ngInject
+ */
+export function ChartingController($scope, $attrs, $element, Utils) {
+  let defaultMargins = {left: 30, top: 10, bottom: 30, right: 10};
+  // TODO: Refactor this so we don't use $scope to store internal state. We
+  // shouldn't be using the $scope variable like that, it leads to "Scope Soup"
+  // which makes the code harder to follow.
+  $scope.config = {};
+
+  $scope.setDefaultMargins = margins => {
+    defaultMargins = margins;
+  };
+
+  // Configures the scope.config object with the defaults selected, overriding from
+  //  directive attributes if the attribute exists
+  // Also initializes the margins object separately from the one-way bound attributes
+  $scope.configure = defaults => {
+    for (const key of Object.keys(defaults)) {
+      const attr = $attrs[key];
+      $scope.config[key] = (attr === undefined) ? defaults[key] : $scope.$eval(attr);
+    }
+    $scope.config.margin = initializeMargins($attrs.margin);
+    $scope.plotComplete = false;
+  };
+
+  // Wrapper for the plot function, called from $scope.$watch
+  $scope.redraw = function (data) {
+    if (!data || $scope.plotComplete || ($scope.config.lazyLoad && !Utils.inViewPort($element))) {
+      return;
+    }
+    $scope.plot(data);
+    if (!$scope.allowRedraw) {
+      $scope.plotComplete = true;
+    }
+  };
+
+  // OVERRIDE
+  $scope.plot = function () {};
+
+  $scope.$watch('data', newData => {
+    $scope.redraw(newData);
+  });
+
+  Utils.onPanelSnap($element, () => {
+    $scope.redraw($scope.data);
+  });
+
+  /**
+   * Init margins when passed either an object with properties left/top/bottom/right or an int
+   *
+   * @param margins Int|Object
+   *
+   * @returns Object {left: Int, top: Int, bottom: Int, right: Int}
+   */
+  function initializeMargins(margins) {
+    let margin = ($scope.$eval(margins) || defaultMargins);
+    if (typeof margin !== 'object') {
+      // we were passed a vanilla int, convert to full margin object
+      margin = {left: margin, top: margin, bottom: margin, right: margin};
+    }
+    return margin;
+  }
+}

--- a/src/app/controllers/index.js
+++ b/src/app/controllers/index.js
@@ -1,0 +1,10 @@
+
+import angular from 'angular';
+
+import {ChartingController} from './charting.controller';
+
+export const adbControllersModule = 'adb.controllers';
+
+angular
+  .module(adbControllersModule, [])
+  .controller('ChartingController', ChartingController);

--- a/src/app/directives/histogram.directive.js
+++ b/src/app/directives/histogram.directive.js
@@ -3,7 +3,8 @@ export const HistogramDefaults = {
   plotWidthPercentage: 0.8,
   barRadius: 1,
   transitionMillis: 500,
-  lazyLoad: false
+  lazyLoad: false,
+  chartColor: '#000000'
 };
 
 export function HistogramDirective($log, HistogramDefaults, d3, _) {
@@ -28,6 +29,7 @@ export function HistogramDirective($log, HistogramDefaults, d3, _) {
       margin: '&',
       calloutValues: '<',
       calloutColors: '<',
+      chartColor: '&',
       transitionMillis: '@',
       allowRedraw: '@',
       lazyLoad: '@'
@@ -103,7 +105,8 @@ export function HistogramDirective($log, HistogramDefaults, d3, _) {
           .range([height, 30]);
         // KDEstimator with probability distribution tapering out with a bandwidth of 0.2
         // with the epanechnikov kernel function
-        const kde = kernelDensityEstimator(epanechnikovKernel(1), xKDE.ticks(100));
+        const bins = buckets(minValue, maxValue, 100);
+        const kde = kernelDensityEstimator(epanechnikovKernel(1), bins);
         const estimate = kde(data); // Estimated density
 
         // Plot KDE and callouts
@@ -118,7 +121,8 @@ export function HistogramDirective($log, HistogramDefaults, d3, _) {
         chart.append('path') // Plot area for KDE
           .datum(estimate)
           .attr('class', 'kde plot')
-          .attr('d', plotArea);
+          .attr('d', plotArea)
+          .attr('fill', $scope.chartColor);
         if (calloutValues) {
           for (let i = 0; i < calloutValues.length; i++) {
             if (calloutValues[i] !== null) { // Don't plot null vals - null is not 0
@@ -140,6 +144,11 @@ export function HistogramDirective($log, HistogramDefaults, d3, _) {
         });
         console.log('Data:', data);
          */
+
+         function buckets(min, max, count) {
+           const delta = (max - min) / (count-1);
+           return _.map(_.range(count), i => min + delta * i);
+         }
 
         function kernelDensityEstimator(kernel, x) {
           return sample => {

--- a/src/app/directives/histogram.directive.js
+++ b/src/app/directives/histogram.directive.js
@@ -1,0 +1,165 @@
+// Define object config of properties for this chart directive
+export const HistogramDefaults = {
+  plotWidthPercentage: 0.8,
+  barRadius: 1,
+  transitionMillis: 500,
+  lazyLoad: false
+};
+
+export function HistogramDirective($log, HistogramDefaults, d3, _) {
+  const PLOT_CLASS = 'adb-histogram';
+
+  // Default color to use when a color isn't provided
+  const defaultColor = 'LightGray';
+
+  // Begin directive module definition
+  const module = {
+    restrict: 'EA',
+    template: '<svg class="chart"></svg>',
+    controller: 'ChartingController',
+    scope: {
+      data: '<',        // Required
+      id: '@',        // Required
+      plotWidth: '<',
+      plotHeight: '<',
+      plotWidthPercentage: '@',
+      barRadius: '@',
+      valueField: '<',     // Required
+      margin: '&',
+      calloutValues: '<',
+      calloutColors: '<',
+      transitionMillis: '@',
+      allowRedraw: '@',
+      lazyLoad: '@'
+    },
+
+    link: ($scope, element, attrs) => {
+      $scope.setDefaultMargins(10);
+      $scope.configure(HistogramDefaults);
+      const config = $scope.config;
+      const margin = config.margin;
+      let calloutValues = $scope.calloutValues;
+      const calloutColors = $scope.calloutColors;
+
+      // D3 margin, sizing, and spacing code
+      element.addClass(PLOT_CLASS);
+      let chartId = attrs.id;
+      if (!chartId) {
+        const randomId = Math.floor(Math.random() * 1000000001).toString();
+        chartId = `adb-histogram-${randomId}`;
+        element.attr('id', chartId);
+      }
+      const chart = d3.select(`#${chartId} svg.chart`)
+        .attr('width', $scope.plotWidth)
+        .attr('height', $scope.plotHeight)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      $scope.$watch('calloutValues', newValue => {
+        calloutValues = newValue;
+        $scope.redraw($scope.data);
+      });
+
+      $scope.$watchGroup(['plotWidth', 'plotHeight'], () => {
+        d3.select(`#${chartId} svg.chart`).attr('width', $scope.plotWidth);
+        $scope.redraw($scope.data);
+      });
+
+      // Overridden ChartingController method
+      /**
+        Data structure:
+      */
+      $scope.plot = data => {
+        if (!$scope.plotWidth || !$scope.plotHeight || !data) {
+          return;
+        }
+
+        // Clear all drawn chart elements before redrawing
+        d3.selectAll(`#${chartId} .chart > g > *`).remove();
+
+        // Filter values < 1 for log scale
+        data = _.chain(data) // Filter out less than 1 and return the log10 of values
+          .filter(row => {
+            return row[$scope.valueField] >= 1;
+          }).map(d => {
+            return Math.log(d[$scope.valueField]) / Math.log(10);
+          }).value();
+
+        if (data.length === 0) {
+          return;
+        }
+
+        const maxValue = _.max(data);
+        const minValue = _.min(data);
+        const height = $scope.plotHeight - margin.top - margin.bottom;
+        const width = $scope.plotWidth - margin.left - margin.right;
+
+        // Scale for log values
+        const xKDE = d3.scale.linear()
+          .domain([minValue, maxValue])
+          .range([0, width]);
+        const yKDE = d3.scale.linear()
+          .domain([0, 1])
+          .range([height, 30]);
+        // KDEstimator with probability distribution tapering out with a bandwidth of 0.2
+        // with the epanechnikov kernel function
+        const kde = kernelDensityEstimator(epanechnikovKernel(1), xKDE.ticks(100));
+        const estimate = kde(data); // Estimated density
+
+        // Plot KDE and callouts
+        const plotArea = d3.svg.area()
+          .x(d => {
+            return xKDE(d[0]);
+          })
+          .y0(height)
+          .y1(d => {
+            return yKDE(d[1]);
+          });
+        chart.append('path') // Plot area for KDE
+          .datum(estimate)
+          .attr('class', 'kde plot')
+          .attr('d', plotArea);
+        if (calloutValues) {
+          for (let i = 0; i < calloutValues.length; i++) {
+            if (calloutValues[i] !== null) { // Don't plot null vals - null is not 0
+              chart.append('rect') // Callouts - minValue is used for cases below 1 to avoid negInfinity on log10
+                .attr('x', xKDE(calloutValues[i] >= 1 ? Math.log(calloutValues[i]) / Math.log(10) : minValue))
+                .attr('y', 0)
+                .attr('height', height)
+                .attr('width', '2px')
+                .attr('fill', calloutColors[i] || defaultColor);
+            }
+          }
+        }
+
+        /* Debugging logs
+        console.log('Config:', {
+          min: minValue,
+          max: maxValue,
+          callouts: calloutValues
+        });
+        console.log('Data:', data);
+         */
+
+        function kernelDensityEstimator(kernel, x) {
+          return sample => {
+            return x.map(x => {
+              return [x, d3.mean(sample, v => {
+                return kernel(x - v);
+              })];
+            });
+          };
+        }
+
+        function epanechnikovKernel(scale) {
+          return function (u) {
+            u /= scale;
+            return Math.abs(u) <= 1 ? 0.75 * (1 - u * u) / scale : 0;
+          };
+        }
+      };
+    }
+  };
+
+  return module;
+}

--- a/src/app/directives/index.js
+++ b/src/app/directives/index.js
@@ -1,0 +1,12 @@
+
+import angular from 'angular';
+
+import {adbControllersModule} from '../controllers/index';
+import {HistogramDirective, HistogramDefaults} from './histogram.directive';
+
+export const adbDirectivesModule = 'adb.directives';
+
+angular
+  .module(adbDirectivesModule, [adbControllersModule])
+  .constant('HistogramDefaults', HistogramDefaults)
+  .directive('adbHistogram', HistogramDirective);

--- a/src/app/factories/index.js
+++ b/src/app/factories/index.js
@@ -2,9 +2,11 @@
 import angular from 'angular';
 
 import {ZoomToDropdownFactory} from './zoomtodropdown.factory';
+import {UtilsFactory} from './utils.factory';
 
 export const adbFactoriesModule = 'adb.factories';
 
 angular
   .module(adbFactoriesModule, [])
+  .factory('Utils', UtilsFactory)
   .factory('ZoomToDropdown', ZoomToDropdownFactory);

--- a/src/app/factories/utils.factory.js
+++ b/src/app/factories/utils.factory.js
@@ -1,0 +1,33 @@
+export function UtilsFactory($document) {
+  const module = {};
+
+  /**
+   *  Checks if an element is currently visible in the viewport
+   *
+   *  @param {DOM element} element to check for visibility
+   *  @returns {boolean} true if the element is currently visible in the viewport
+   */
+  module.inViewPort = function (element) {
+    const height = $document[0].documentElement.clientHeight;
+    const width = $document[0].documentElement.clientWidth;
+    const r = element[0].getBoundingClientRect();
+    return r.top >= 0 && r.bottom <= height && r.left >= 0 && r.right <= width;
+  };
+
+  /**
+   *  Triggers a callback when a panel snap occurs
+   *
+   *  @param {DOM element} child element of a panel snap container
+   *  @param {function} callback that is called when the panel snaps
+   */
+  module.onPanelSnap = function (element, callback) {
+    while (element.parentElement) {
+      element = element.parentElement;
+      element.on('panelsnap:finish', event => {
+        callback(event);
+      });
+    }
+  };
+
+  return module;
+}

--- a/src/app/services/soum-data.service.js
+++ b/src/app/services/soum-data.service.js
@@ -4,7 +4,8 @@ const cartodb = require('cartodb');
 export function SoumData($log, $http, $q, Config) {
   return {
     geojson,
-    load
+    load,
+    compare
   };
 
   function geojson(soumId) {
@@ -31,6 +32,18 @@ export function SoumData($log, $http, $q, Config) {
       // Done!
       return soum;
     });
+  }
+
+  function compare(column) {
+    // Given a soumId return the geojson boundary for it
+    // Wrap in angular promise so we're consistent with the types of promises we're
+    //  using in public APIs
+    const dfd = $q.defer();
+    const sql = new cartodb.SQL({user: Config.carto.accountName});
+    sql.execute(`SELECT {{column}} FROM soums`, {column})
+      .done(data => dfd.resolve(data))
+      .error(error => dfd.reject(error));
+    return dfd.promise;
   }
 
   function mergeResponses(responses) {

--- a/src/app/services/soum-data.service.js
+++ b/src/app/services/soum-data.service.js
@@ -56,24 +56,22 @@ export function SoumData($log, $http, $q, Config, _) {
   }
 
   function _parseCompare(data, soumId, columns) {
-    const comparison = {};
-
     const rows = data.rows;
-
     const soumRow = _.find(rows, {soumcode: soumId});
+
+    const comparison = {
+      country: {},
+      cluster: {},
+      soum: soumRow
+    };
+
     for (const column of columns) {
       const colData = _.map(rows, column);
       const clusterRows = _.filter(rows, {neighbor: true});
       const clusterData = _.map(clusterRows, column);
 
-      const soumVal = soumRow[column];
-      const regionAvg = clusterData.reduce((sum, val) => sum + val, 0) / clusterData.length;
-      const countryAvg = colData.reduce((sum, val) => sum + val, 0) / colData.length;
-      comparison[column] = [
-        countryAvg,
-        regionAvg,
-        soumVal
-      ];
+      comparison.country[column] = colData.reduce((sum, val) => sum + val, 0) / colData.length;
+      comparison.cluster[column] = clusterData.reduce((sum, val) => sum + val, 0) / clusterData.length;
     }
     return {rows, comparison};
   }

--- a/src/app/views/data/data.html
+++ b/src/app/views/data/data.html
@@ -21,6 +21,22 @@
           <adb-infoblock-view variable="$ctrl.soum.people.pchn9514" class="panel half"></adb-infoblock-view>
         </div>
         <div class="flex-grid">
+          <div class="panel histogram">
+            <div class="panel-content text-center">
+              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.soum.people[$ctrl.charts.fields.people].title }}"></p>
+              <adb-histogram
+                plot-height="$ctrl.charts.height"
+                plot-width="$ctrl.charts.width"
+                data="$ctrl.charts.data"
+                callout-values="[$ctrl.soum.people[$ctrl.charts.fields.people].value]"
+                callout-colors="$ctrl.charts.calloutColors"
+                value-field="$ctrl.charts.fields.people"
+                allow-redraw="true">
+              </adb-histogram>
+            </div>
+          </div>
+        </div>
+        <div class="flex-grid">
           <adb-infoblock-view variable="$ctrl.soum.people.sh14" class="panel third"></adb-infoblock-view>
           <adb-infoblock-view variable="$ctrl.soum.people.shch9514" class="panel third"></adb-infoblock-view>
           <adb-infoblock-view variable="$ctrl.soum.people.den14" class="panel third"></adb-infoblock-view>
@@ -36,6 +52,22 @@
         <div class="flex-grid">
           <adb-infoblock-view variable="$ctrl.soum.households.hh14" class="panel half"></adb-infoblock-view>
           <adb-infoblock-view variable="$ctrl.soum.households.chnhh614" class="panel half"></adb-infoblock-view>
+        </div>
+        <div class="flex-grid">
+          <div class="panel histogram">
+            <div class="panel-content text-center">
+              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.soum.households[$ctrl.charts.fields.households].title }}"></p>
+              <adb-histogram
+                plot-height="$ctrl.charts.height"
+                plot-width="$ctrl.charts.width"
+                data="$ctrl.charts.data"
+                callout-values="[$ctrl.soum.households[$ctrl.charts.fields.households].value]"
+                callout-colors="$ctrl.charts.calloutColors"
+                value-field="$ctrl.charts.fields.households"
+                allow-redraw="true">
+              </adb-histogram>
+            </div>
+          </div>
         </div>
         <div class="flex-grid">
           <adb-infoblock-view variable="$ctrl.soum.households.hhh14" class="panel third"></adb-infoblock-view>
@@ -56,6 +88,22 @@
             <adb-infoblock-view variable="$ctrl.soum.economy.sdi" class="panel third"></adb-infoblock-view>
         </div>
         <div class="flex-grid">
+          <div class="panel histogram">
+            <div class="panel-content text-center">
+              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.soum.economy[$ctrl.charts.fields.economy].title }}"></p>
+              <adb-histogram
+                plot-height="$ctrl.charts.height"
+                plot-width="$ctrl.charts.width"
+                data="$ctrl.charts.data"
+                callout-values="[$ctrl.soum.economy[$ctrl.charts.fields.economy].value]"
+                callout-colors="$ctrl.charts.calloutColors"
+                value-field="$ctrl.charts.fields.economy"
+                allow-redraw="true">
+              </adb-histogram>
+            </div>
+          </div>
+        </div>
+        <div class="flex-grid">
           <adb-infoblock-view variable="$ctrl.soum.economy.man14" class="panel"></adb-infoblock-view>
           <adb-infoblock-view variable="$ctrl.soum.economy.chman0014" class="panel"></adb-infoblock-view>
           <!-- <adb-infoblock-view variable="$ctrl.soum.economy.pcpov11" class="panel"></adb-infoblock-view> -->
@@ -73,6 +121,22 @@
           <adb-infoblock-view variable="$ctrl.soum.infrastructure.pcger10" class="panel"></adb-infoblock-view>
           <adb-infoblock-view variable="$ctrl.soum.infrastructure.pcsan10" class="panel"></adb-infoblock-view>
           <adb-infoblock-view variable="$ctrl.soum.infrastructure.pcwat10" class="panel"></adb-infoblock-view>
+        </div>
+        <div class="flex-grid">
+          <div class="panel histogram">
+            <div class="panel-content text-center">
+              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.soum.infrastructure[$ctrl.charts.fields.infrastructure].title }}"></p>
+              <adb-histogram
+                plot-height="$ctrl.charts.height"
+                plot-width="$ctrl.charts.width"
+                data="$ctrl.charts.data"
+                callout-values="[$ctrl.soum.infrastructure[$ctrl.charts.fields.infrastructure].value]"
+                callout-colors="$ctrl.charts.calloutColors"
+                value-field="$ctrl.charts.fields.infrastructure"
+                allow-redraw="true">
+              </adb-histogram>
+            </div>
+          </div>
         </div>
         <div class="flex-grid">
           <adb-infoblock-view variable="$ctrl.soum.infrastructure.pcsw10" class="panel"></adb-infoblock-view>

--- a/src/app/views/data/data.html
+++ b/src/app/views/data/data.html
@@ -23,15 +23,14 @@
         <div class="flex-grid">
           <div class="panel histogram">
             <div class="panel-content text-center">
-              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.soum.people[$ctrl.charts.fields.people].title }}"></p>
+              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.charts.histograms.people.title }}"></p>
               <adb-histogram
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
-                callout-values="$ctrl.charts.calloutValues.people"
-                callout-colors="$ctrl.charts.calloutColors"
-                value-field="$ctrl.charts.fields.people"
-                chart-color="$ctrl.charts.color"
+                callouts="$ctrl.charts.calloutList"
+                value-field="$ctrl.charts.histograms.people.field"
+                chart-color="$ctrl.charts.fillColor"
                 allow-redraw="true">
               </adb-histogram>
             </div>
@@ -57,15 +56,14 @@
         <div class="flex-grid">
           <div class="panel histogram">
             <div class="panel-content text-center">
-              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.soum.households[$ctrl.charts.fields.households].title }}"></p>
+              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.charts.histograms.households.title }}"></p>
               <adb-histogram
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
-                callout-values="$ctrl.charts.calloutValues.households"
-                callout-colors="$ctrl.charts.calloutColors"
-                value-field="$ctrl.charts.fields.households"
-                chart-color="$ctrl.charts.color"
+                callouts="$ctrl.charts.calloutList"
+                value-field="$ctrl.charts.histograms.households.field"
+                chart-color="$ctrl.charts.fillColor"
                 allow-redraw="true">
               </adb-histogram>
             </div>
@@ -92,15 +90,14 @@
         <div class="flex-grid">
           <div class="panel histogram">
             <div class="panel-content text-center">
-              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.soum.economy[$ctrl.charts.fields.economy].title }}"></p>
+              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.charts.fields.economy.title }}"></p>
               <adb-histogram
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
-                callout-values="$ctrl.charts.calloutValues.economy"
-                callout-colors="$ctrl.charts.calloutColors"
-                value-field="$ctrl.charts.fields.economy"
-                chart-color="$ctrl.charts.color"
+                callouts="$ctrl.charts.calloutList"
+                value-field="$ctrl.charts.histograms.economy.field"
+                chart-color="$ctrl.charts.fillColor"
                 allow-redraw="true">
               </adb-histogram>
             </div>
@@ -128,15 +125,14 @@
         <div class="flex-grid">
           <div class="panel histogram">
             <div class="panel-content text-center">
-              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.soum.infrastructure[$ctrl.charts.fields.infrastructure].title }}"></p>
+              <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.charts.fields.infrastructure.title }}"></p>
               <adb-histogram
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
-                callout-values="$ctrl.charts.calloutValues.infrastructure"
-                callout-colors="$ctrl.charts.calloutColors"
-                value-field="$ctrl.charts.fields.infrastructure"
-                chart-color="$ctrl.charts.color"
+                callouts="$ctrl.charts.calloutList"
+                value-field="$ctrl.charts.histograms.infrastructure.field"
+                chart-color="$ctrl.charts.fillColor"
                 allow-redraw="true">
               </adb-histogram>
             </div>

--- a/src/app/views/data/data.html
+++ b/src/app/views/data/data.html
@@ -28,9 +28,10 @@
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
-                callout-values="[$ctrl.soum.people[$ctrl.charts.fields.people].value]"
+                callout-values="$ctrl.charts.calloutValues.people"
                 callout-colors="$ctrl.charts.calloutColors"
                 value-field="$ctrl.charts.fields.people"
+                chart-color="$ctrl.charts.color"
                 allow-redraw="true">
               </adb-histogram>
             </div>
@@ -61,9 +62,10 @@
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
-                callout-values="[$ctrl.soum.households[$ctrl.charts.fields.households].value]"
+                callout-values="$ctrl.charts.calloutValues.households"
                 callout-colors="$ctrl.charts.calloutColors"
                 value-field="$ctrl.charts.fields.households"
+                chart-color="$ctrl.charts.color"
                 allow-redraw="true">
               </adb-histogram>
             </div>
@@ -95,9 +97,10 @@
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
-                callout-values="[$ctrl.soum.economy[$ctrl.charts.fields.economy].value]"
+                callout-values="$ctrl.charts.calloutValues.economy"
                 callout-colors="$ctrl.charts.calloutColors"
                 value-field="$ctrl.charts.fields.economy"
+                chart-color="$ctrl.charts.color"
                 allow-redraw="true">
               </adb-histogram>
             </div>
@@ -130,9 +133,10 @@
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
-                callout-values="[$ctrl.soum.infrastructure[$ctrl.charts.fields.infrastructure].value]"
+                callout-values="$ctrl.charts.calloutValues.infrastructure"
                 callout-colors="$ctrl.charts.calloutColors"
                 value-field="$ctrl.charts.fields.infrastructure"
+                chart-color="$ctrl.charts.color"
                 allow-redraw="true">
               </adb-histogram>
             </div>

--- a/src/app/views/data/data.html
+++ b/src/app/views/data/data.html
@@ -24,7 +24,12 @@
           <div class="panel histogram">
             <div class="panel-content text-center">
               <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.charts.histograms.people.title }}"></p>
+              <div class="spinner" ng-if="!$ctrl.charts.data">
+                <div class="dot1"></div>
+                <div class="dot2"></div>
+              </div>
               <adb-histogram
+                ng-if="$ctrl.charts.data"
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
@@ -57,7 +62,12 @@
           <div class="panel histogram">
             <div class="panel-content text-center">
               <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.charts.histograms.households.title }}"></p>
+              <div class="spinner" ng-if="!$ctrl.charts.data">
+                <div class="dot1"></div>
+                <div class="dot2"></div>
+              </div>
               <adb-histogram
+                ng-if="$ctrl.charts.data"
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
@@ -91,7 +101,12 @@
           <div class="panel histogram">
             <div class="panel-content text-center">
               <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.charts.fields.economy.title }}"></p>
+              <div class="spinner" ng-if="!$ctrl.charts.data">
+                <div class="dot1"></div>
+                <div class="dot2"></div>
+              </div>
               <adb-histogram
+                ng-if="$ctrl.charts.data"
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"
@@ -126,7 +141,12 @@
           <div class="panel histogram">
             <div class="panel-content text-center">
               <p class="font-alt color-light text-uppercase" translate="{{ $ctrl.charts.fields.infrastructure.title }}"></p>
+              <div class="spinner" ng-if="!$ctrl.charts.data">
+                <div class="dot1"></div>
+                <div class="dot2"></div>
+              </div>
               <adb-histogram
+                ng-if="$ctrl.charts.data"
                 plot-height="$ctrl.charts.height"
                 plot-width="$ctrl.charts.width"
                 data="$ctrl.charts.data"

--- a/src/app/views/data/data.js
+++ b/src/app/views/data/data.js
@@ -18,22 +18,11 @@ class DataViewController extends ADBMapController {
   $onInit() {
     super.$onInit();
 
-    this.charts = {
-      fields: {
-        people: 'den14',
-        households: 'hh14',
-        economy: 'ent14',
-        infrastructure: 'pcwat10'
-      },
-      height: 300,
-      width: undefined,
-      data: undefined,
-      calloutColors: ['#8FBD84']
-    };
+    this.charts = this.config.charts;
 
     angular.element(this.$window).bind('resize', this._onResize.bind(this));
 
-    this.soumCode = this.$stateParams.soumCode;
+    this.soumCode = Number.parseInt(this.$stateParams.soumCode, 10);
     this.$log.debug('soum code:', this.soumCode);
 
     this.soumData.geojson(this.soumCode).then(geojson => this._addGeoJSONLayer(geojson));
@@ -45,7 +34,7 @@ class DataViewController extends ADBMapController {
       compareColumns.push(field);
     }
 
-    this.soumData.compare(compareColumns).then(data => this.charts.data = data.rows); // eslint-disable-line no-return-assign
+    this.soumData.compare(this.soumCode, compareColumns).then(data => this._setChartData(data));
 
     // Simulate a resize to get initial widths for the histograms
     this._onResize();
@@ -63,6 +52,15 @@ class DataViewController extends ADBMapController {
   _onResize() {
     this.charts.width = document.querySelectorAll(".histogram .panel-content p")[0].clientWidth;
     this.$timeout(() => this.$scope.$apply());
+  }
+
+  _setChartData(data) {
+    this.charts.data = data.rows;
+    this.charts.calloutValues = {};
+    for (const field of Object.keys(this.charts.fields)) {
+      const column = this.charts.fields[field];
+      this.charts.calloutValues[field] = data.comparison[column];
+    }
   }
 }
 

--- a/src/app/views/data/data.js
+++ b/src/app/views/data/data.js
@@ -5,12 +5,13 @@ const L = require('leaflet');
 class DataViewController extends ADBMapController {
 
   /** @ngInject */
-  constructor($window, $filter, $log, $scope, $stateParams, Config, SoumData) {
+  constructor($window, $filter, $log, $scope, $stateParams, $timeout, $q, Config, SoumData) {
     super($filter, Config, 'dataMap');
     this.$log = $log;
     this.$scope = $scope;
     this.$stateParams = $stateParams;
     this.soumData = SoumData;
+    this.$timeout = $timeout;
     this.$window = $window;
   }
 
@@ -61,7 +62,7 @@ class DataViewController extends ADBMapController {
 
   _onResize() {
     this.charts.width = document.querySelectorAll(".histogram .panel-content p")[0].clientWidth;
-    this.$scope.$apply();
+    this.$timeout(() => this.$scope.$apply());
   }
 }
 

--- a/src/app/views/data/data.js
+++ b/src/app/views/data/data.js
@@ -5,21 +5,49 @@ const L = require('leaflet');
 class DataViewController extends ADBMapController {
 
   /** @ngInject */
-  constructor($filter, $log, $stateParams, Config, SoumData) {
+  constructor($window, $filter, $log, $scope, $stateParams, Config, SoumData) {
     super($filter, Config, 'dataMap');
     this.$log = $log;
+    this.$scope = $scope;
     this.$stateParams = $stateParams;
     this.soumData = SoumData;
+    this.$window = $window;
   }
 
   $onInit() {
     super.$onInit();
+
+    this.charts = {
+      fields: {
+        people: 'den14',
+        households: 'hh14',
+        economy: 'ent14',
+        infrastructure: 'pcwat10'
+      },
+      height: 300,
+      width: undefined,
+      data: undefined,
+      calloutColors: ['#8FBD84']
+    };
+
+    angular.element(this.$window).bind('resize', this._onResize.bind(this));
 
     this.soumCode = this.$stateParams.soumCode;
     this.$log.debug('soum code:', this.soumCode);
 
     this.soumData.geojson(this.soumCode).then(geojson => this._addGeoJSONLayer(geojson));
     this.soumData.load(this.soumCode).then(soum => this.soum = soum); // eslint-disable-line no-return-assign
+
+    const compareColumns = [];
+    for (const type of Object.keys(this.charts.fields)) {
+      const field = this.charts.fields[type];
+      compareColumns.push(field);
+    }
+
+    this.soumData.compare(compareColumns).then(data => this.charts.data = data.rows); // eslint-disable-line no-return-assign
+
+    // Simulate a resize to get initial widths for the histograms
+    this._onResize();
   }
 
   _setupMap(options) {
@@ -29,6 +57,11 @@ class DataViewController extends ADBMapController {
 
   _addGeoJSONLayer(geojson) {
     L.geoJson(geojson).addTo(this.map);
+  }
+
+  _onResize() {
+    this.charts.width = document.querySelectorAll(".histogram .panel-content p")[0].clientWidth;
+    this.$scope.$apply();
   }
 }
 

--- a/src/app/views/data/data.js
+++ b/src/app/views/data/data.js
@@ -23,7 +23,7 @@ class DataViewController extends ADBMapController {
     // Initialize the histogram charts configuration
     this.charts = this.config.charts;
     this.charts.calloutList = [];
-    this.charts.data = [];
+    this.charts.data = undefined;
 
     angular.element(this.$window).bind('resize', this._onResize.bind(this));
 

--- a/src/app/views/index.js
+++ b/src/app/views/index.js
@@ -8,6 +8,8 @@ import {adbDataView} from './data/data';
 import {adbInfoblockView} from './infoblock/infoblock';
 import {appConfig} from '../../config';
 import {adbLangModule} from '../i18n/index';
+import {adbControllersModule} from '../controllers/index';
+import {adbDirectivesModule} from '../directives/index';
 import {adbServicesModule} from '../services/index';
 import {adbFactoriesModule} from '../factories/index';
 import {adbFiltersModule} from '../filters/index';
@@ -15,7 +17,8 @@ import {adbFiltersModule} from '../filters/index';
 export const adbViewModule = 'adb.views';
 
 angular
-  .module(adbViewModule, [appConfig, adbLangModule, adbServicesModule, adbFiltersModule, adbFactoriesModule])
+  .module(adbViewModule, [appConfig, adbLangModule, adbControllersModule, adbDirectivesModule,
+                          adbServicesModule, adbFiltersModule, adbFactoriesModule])
   .component('adbNavbarView', adbNavbarView)
   .component('adbHomeView', adbHomeView)
   .component('adbMapView', adbMapView)

--- a/src/assets/sass/main.scss
+++ b/src/assets/sass/main.scss
@@ -47,10 +47,11 @@
  * Pages
  */
 @import
-  "pages/home";
+  "pages/home",
+  "pages/data";
 
 
-/* 
+/*
  * Print Style
  */
 @import

--- a/src/assets/sass/pages/_data.scss
+++ b/src/assets/sass/pages/_data.scss
@@ -14,3 +14,52 @@ adb-histogram .legend {
     margin: 5px;
   }
 }
+
+.spinner {
+  margin: 100px auto;
+  width: 40px;
+  height: 40px;
+  position: relative;
+  text-align: center;
+
+  -webkit-animation: sk-rotate 2.0s infinite linear;
+  animation: sk-rotate 2.0s infinite linear;
+}
+
+.dot1, .dot2 {
+  width: 60%;
+  height: 60%;
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  background-color: #333;
+  border-radius: 100%;
+
+  -webkit-animation: sk-bounce 2.0s infinite ease-in-out;
+  animation: sk-bounce 2.0s infinite ease-in-out;
+}
+
+.dot2 {
+  top: auto;
+  bottom: 0;
+  -webkit-animation-delay: -1.0s;
+  animation-delay: -1.0s;
+}
+
+@-webkit-keyframes sk-rotate { 100% { -webkit-transform: rotate(360deg) }}
+@keyframes sk-rotate { 100% { transform: rotate(360deg); -webkit-transform: rotate(360deg) }}
+
+@-webkit-keyframes sk-bounce {
+  0%, 100% { -webkit-transform: scale(0.0) }
+  50% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes sk-bounce {
+  0%, 100% {
+    transform: scale(0.0);
+    -webkit-transform: scale(0.0);
+  } 50% {
+    transform: scale(1.0);
+    -webkit-transform: scale(1.0);
+  }
+}

--- a/src/assets/sass/pages/_data.scss
+++ b/src/assets/sass/pages/_data.scss
@@ -1,0 +1,16 @@
+adb-histogram .legend {
+  display: flex;
+  list-style: none;
+
+  i:before {
+    content: "+";
+  }
+
+  em:before {
+    content: " - ";
+  }
+
+  li {
+    margin: 5px;
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -194,6 +194,22 @@ const config = {
         isPercent: true
       }]
     }
+  },
+  charts: {
+    fields: {
+      people: 'den14',
+      households: 'hh14',
+      economy: 'ent14',
+      infrastructure: 'pcwat10'
+    },
+    height: 300,
+    width: undefined, // Width is dynamically detected from page state
+    calloutColors: [ // Callouts are the vertical bars representing specific values
+      '#FF0000', // Country
+      '#00FF00', // Region
+      '#0000FF'  // Soum
+    ],
+    color: '#FFFF00'
   }
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -196,20 +196,43 @@ const config = {
     }
   },
   charts: {
-    fields: {
-      people: 'den14',
-      households: 'hh14',
-      economy: 'ent14',
-      infrastructure: 'pcwat10'
+    histograms: {
+      people: {
+        field: 'den14',
+        title: 'HISTOGRAM_PEOPLE_TITLE'
+      },
+      households: {
+        field: 'hh14',
+        title: 'HISTOGRAM_HOUSEHOLDS_TITLE'
+      },
+      economy: {
+        field: 'ent14',
+        title: 'HISTOGRAM_ECONOMY_TITLE'
+      },
+      infrastructure: {
+        field: 'pcwat10',
+        title: 'HISTOGRAM_INFRASTRUCTURE_TITLE'
+      }
     },
-    height: 300,
+    height: 200,
     width: undefined, // Width is dynamically detected from page state
-    calloutColors: [ // Callouts are the vertical bars representing specific values
-      '#FF0000', // Country
-      '#00FF00', // Region
-      '#0000FF'  // Soum
-    ],
-    color: '#FFFF00'
+    callouts: { // Callouts are the vertical bars representing specific values
+      // The country, cluster and soum keys are to match the SoumData.compare response,
+      // which gives averaged values for metrics at the country, cluster and soum levels.
+      country: {
+        label: 'COUNTRY_LEGEND_LABEL',
+        color: '#FF0000'
+      },
+      cluster: {
+        label: 'CLUSTER_LEGEND_LABEL',
+        color: '#0000FF'
+      },
+      soum: {
+        label: undefined, // Overriden by the Soum's name
+        color: '#00FF00'
+      }
+    },
+    fillColor: '#FFFF00'
   }
 };
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -38,6 +38,13 @@ export const en = {
   DATA_SOUM_HIERARCHY: 'Mongolia, {{aimag_name}}, {{soum_name}}',
   DATA_BACK_TO_MAP: 'Back to Map',
 
+  HISTOGRAM_PEOPLE_TITLE: 'Distribution of population density by soum',
+  HISTOGRAM_HOUSEHOLDS_TITLE: 'Distribution of # of households by soum',
+  HISTOGRAM_ECONOMY_TITLE: 'Distribution of total # of enterprises by soum',
+  HISTOGRAM_INFRASTRUCTURE_TITLE: 'Distribution of % of population with access to piped water by soum',
+  COUNTRY_LEGEND_LABEL: 'Country average',
+  CLUSTER_LEGEND_LABEL: 'Cluster average',
+
   MAP_OSM_ATTRIBUTION: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
   MAP_ARCGIS_WORLD_IMAGERY_ATTRIBUTION: 'Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community',
   MAP_ARCGIS_WORLD_TOPO_MAP_ATTRIBUTION: 'Sources: Esri, HERE, DeLorme, Intermap, increment P Corp., GEBCO, USGS, FAO, NPS, NRCAN, GeoBase, IGN, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), swisstopo, MapmyIndia, Â© OpenStreetMap contributors, and the GIS User Community',

--- a/src/i18n/mn.js
+++ b/src/i18n/mn.js
@@ -38,6 +38,13 @@ export const mn = {
   DATA_SOUM_HIERARCHY: '!Mongolia, {{aimag_name}}, {{soum_name}}',
   DATA_BACK_TO_MAP: '!Back to Map',
 
+  HISTOGRAM_PEOPLE_TITLE: '!Distribution of population density by soum',
+  HISTOGRAM_HOUSEHOLDS_TITLE: '!Distribution of # of households by soum',
+  HISTOGRAM_ECONOMY_TITLE: '!Distribution of total # of enterprises by soum',
+  HISTOGRAM_INFRASTRUCTURE_TITLE: '!Distribution of % of population with access to piped water by soum',
+  COUNTRY_LEGEND_LABEL: '!Country average',
+  CLUSTER_LEGEND_LABEL: '!Cluster average',
+
   MAP_OSM_ATTRIBUTION: '!&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
   MAP_ARCGIS_WORLD_IMAGERY_ATTRIBUTION: '!Source: Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community',
   MAP_ARCGIS_WORLD_TOPO_MAP_ATTRIBUTION: '!Sources: Esri, HERE, DeLorme, Intermap, increment P Corp., GEBCO, USGS, FAO, NPS, NRCAN, GeoBase, IGN, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), swisstopo, MapmyIndia, Â© OpenStreetMap contributors, and the GIS User Community',

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import angular from 'angular';
 
+import * as _ from 'lodash';
+import * as d3 from 'd3';
+
 import {adbViewModule} from './app/views/index';
 import 'angular-ui-router';
 import 'angular-translate/dist/angular-translate';
@@ -12,5 +15,7 @@ import './assets/fonts/fontello/css/fontello.css';
 
 angular
   .module('app', [adbViewModule, 'ui.router', 'pascalprecht.translate'])
+  .constant('_', _)
+  .constant('d3', d3)
   .config(routesConfig)
   .config(translateConfig);


### PR DESCRIPTION
## Work in Progress

Issues remaining:
- [x] Responsive design - size graph based on viewport size
- [x] Compare soum to other soums within region when possible, only fall back to global
- [x] (Desired) Axis labels
- [x] Histogram legend
- [ ] Better colors
## Overview

Introduces comparative graphs into the soum data page, showing how the soum compares to other soums in a sample of metrics.
### Notes

The histogram is rendered as an SVG via D3, which unfortunately means that it is non-interactive
### Media

(Note that colors are intentionally gross, they'll be cleaned up in a later PR along with the legend styling)

Soum that does not belong to a cluster:
![screen shot 2016-09-26 at 11 59 37 am](https://cloud.githubusercontent.com/assets/1032849/18841766/c77c5b96-83e0-11e6-8c0b-bd51aae475d5.png)

Soum from within Ulaanbaatar
![screen shot 2016-09-26 at 11 59 22 am](https://cloud.githubusercontent.com/assets/1032849/18841760/c330a4b6-83e0-11e6-9e2e-b39ed7f877ac.png)
## Testing

Navigate to the Data page for a soum via the Map page. You should see 4 histogram graphs through the page, one for each major section (People, Households, etc). Each graph should show a silhouette representing the distribution of that metric across other soums, along with two to three vertical bars showing where the selected soum lies in comparison of the country and (if applicable) its cluster.

Connects with #24
