### PR TITLE
Display "no data available" for null values

### DIFF
--- a/src/app/filters/comparatize.filter.js
+++ b/src/app/filters/comparatize.filter.js
@@ -1,11 +1,14 @@
 /** @ngInject */
-export function Comparatize($log, numberFilter) {
+export function Comparatize($log, $filter, numberFilter) {
   return function (value, isComparison, isPercent) {
     if (value === undefined) {
       // The filter was called before the form's controller was instantiated.
       // Returning undefined tells Angular that the value is still being
       // calculated and causes the filter to play nicely with one-time-bindings.
       return value;
+    }
+    if (value === null) {
+      return $filter('translate')("DATA_NO_DATA");
     }
 
     // Round to 2 digits to work around numberFilter's 3 digit default

--- a/src/app/views/infoblock/infoblock.js
+++ b/src/app/views/infoblock/infoblock.js
@@ -16,7 +16,9 @@ class InfoblockController {
     this.isPercent = this.variable.isPercent;
 
     this.colorClass = '';
-    if (this.isChange && this.value !== 0) {
+    if (this.value === null) {
+      this.colorClass = 'no-data';
+    } else if (this.isChange && this.value !== 0) {
       let ispositive = (this.value > 0);
       if (this.variable.reverseColor) {
         ispositive = !ispositive;

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -39,6 +39,7 @@ export const en = {
   DATA_SOUM_HIERARCHY: 'Mongolia, {{aimag_name}}, {{soum_name}}',
   DATA_KHOROO_HIERARCHY: 'Mongolia, Ulaanbaatar, {{khoroo_name}}',
   DATA_BACK_TO_MAP: 'Back to Map',
+  DATA_NO_DATA: 'No data available',
 
   HISTOGRAM_PEOPLE_TITLE: 'Distribution of population density by soum',
   HISTOGRAM_HOUSEHOLDS_TITLE: 'Distribution of # of households by soum',

--- a/src/i18n/mn.js
+++ b/src/i18n/mn.js
@@ -38,6 +38,7 @@ export const mn = {
   DATA_SOUM_HIERARCHY: 'Монгол улс, {{aimag_name}}, {{soum_name}}',
   DATA_KHOROO_HIERARCHY: '!Mongolia, Ulaanbaatar, {{khoroo_name}}',
   DATA_BACK_TO_MAP: 'Газрын зураг руу буцах',
+  DATA_NO_DATA: '!No data available',
 
   MAP_OSM_ATTRIBUTION: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
   MAP_VIZ_POP: '2014 оны хүн ам',


### PR DESCRIPTION
Because some Khoroos have incomplete data, rather that coerce the database `null` into a 0 we want to display a phrase for each value we do not have data for explaining that there is no data to display:
<img width="1053" alt="screen shot 2016-10-20 at 12 09 02 pm" src="https://cloud.githubusercontent.com/assets/1032849/19568066/1006fb56-96be-11e6-8f06-c0ff065620e6.png">

An example of a Khoroo missing data that can be tested is Baganuur_4, at `/#!/ulaanbaatar/data/BN_4`
