### PR TITLE
replace anonymous font with ubuntu mono, fix cyrillic issue

### DIFF
--- a/src/assets/sass/base/_base.scss
+++ b/src/assets/sass/base/_base.scss
@@ -10,7 +10,7 @@ html {
 		font-family: 'PT Sans', sans-serif;
 
 		.font-alt {
-			font-family: 'Anonymous Pro', sans-serif;
+			font-family: 'Ubuntu Mono', monospace;
 		}
 	}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
 
     <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
-    <link href="https://fonts.googleapis.com/css?family=Anonymous+Pro:400,700|Lato:400,700|PT+Sans:400,700|Quantico:400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu+Mono|Lato:400,700|PT+Sans:400,700|Quantico:400,700" rel="stylesheet">
   </head>
 
   <body ng-app="app">


### PR DESCRIPTION
The anonymous font did not have full support for cyrillic languages. It was missing a few characters so the browser replaced them with fallbacks which looked odd.

Ubuntu mono should fix this issue.

the  Ө and Ү in this screenshot look fine now.
<img width="124" alt="screen shot 2016-10-27 at 10 31 04 am" src="https://cloud.githubusercontent.com/assets/1928955/19771372/b28abf30-9c30-11e6-971b-078e19c54c40.png">
